### PR TITLE
Update rancher/cli and k8s-kubectl

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM lachlanevenson/k8s-kubectl:v1.11.0 AS k8scli
+FROM lachlanevenson/k8s-kubectl:v1.12.1 AS k8scli
 
-FROM rancher/cli:v2.0.2
+FROM rancher/cli:v2.0.5
 
 COPY --from=k8scli /usr/local/bin/kubectl /usr/local/bin
 


### PR DESCRIPTION
This updates rancher/cli to v2.0.5 and k8s-kubectl to v1.12.1.

This also have this [issue](https://github.com/rancher/rancher/issues/14448) fixed.
It will be good for CI as now you can select the context on login just passing the project id.